### PR TITLE
Ignore videos with length less than 30 mins.

### DIFF
--- a/TwitchVods.Core/Twitch/VideoFetcher.cs
+++ b/TwitchVods.Core/Twitch/VideoFetcher.cs
@@ -9,7 +9,8 @@ namespace TwitchVods.Core.Twitch
     // https://github.com/justintv/twitch-api
     public class VideoFetcher : TwitchBase
     {
-
+        private const int ThirtyMinutes = 30 * 60;
+        
         public VideoFetcher(string twitchApiClientId) : base(twitchApiClientId) { }
 
         public async Task<int> GetTotalVideoCount(string channelName)
@@ -56,7 +57,11 @@ namespace TwitchVods.Core.Twitch
                 foreach (var data in jsonData.videos)
                 {
                     var video = Video.FromJson(data);
-                    videos.Add(video);
+                    if (video.Length >= ThirtyMinutes)
+                    {
+                        videos.Add(video);
+                    }   
+
                 }
             }
             return videos;


### PR DESCRIPTION
This changes lirik's result from
```
Total video views: 18,415,808.
Total games played: 1,068.
Total broadcast hours: 11,778 (490 days).
Average length of broadcast: 4h 25m 4s.
```
to
```
Total video views: 17,969,132.
Total games played: 1,066.
Total broadcast hours: 11,737 (489 days).
Average length of broadcast: 5h 13m 58s.
```

**Thanks for the work btw**